### PR TITLE
Dockerfile: udpate base image to alpine 3.10

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
-FROM golang:1.10.3-alpine3.8
+FROM golang:1.13-alpine3.10
 
 RUN apk add --no-cache --update alpine-sdk bash
 
 COPY . /go/src/github.com/mintel/dex-k8s-authenticator
 WORKDIR /go/src/github.com/mintel/dex-k8s-authenticator
-RUN make get && make 
+RUN make get && make
 
-FROM alpine:3.8
+FROM alpine:3.10.3
 # Dex connectors, such as GitHub and Google logins require root certificates.
 # Proper installations should manage those certificates, but it's a bad user
 # experience when this doesn't work out of the box.


### PR DESCRIPTION
JIRA: https://jira.mesosphere.com/browse/DCOS-62697

This matches upstream version https://github.com/mintel/dex-k8s-authenticator/commit/1ff8c3226722e3682e0f90de4e48020a986afdcf#diff-3254677a7917c6c01f55212f86c57fbf