### PR TITLE
feat: enable async auth plugin support

### DIFF
--- a/asyncauth.go
+++ b/asyncauth.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/hex"
 	"fmt"
 	"log"
 	"net/http"
@@ -38,7 +39,7 @@ func SetupAsyncAuth(cluster *Cluster, st storage.TokenStore, basePrefix string) 
 		},
 		Provider:    cluster.Provider,
 		HmacTTL:     HmacTTL,
-		HmacSecret:  []byte(cluster.Config.Hmac_Secret),
+		HmacSecret:  parseSecret(&cluster.Config),
 		Storage:     st,
 		OIDCContext: ctx,
 	}
@@ -65,4 +66,13 @@ func register(name, base, endpoint string, f func(w http.ResponseWriter, req *ht
 
 func join(base, endpoint string) string {
 	return fmt.Sprintf("%s/%s", strings.TrimRight(base, "/"), strings.TrimLeft(endpoint, "/"))
+}
+
+// attempts to decode binary
+func parseSecret(config *Config) []byte {
+	b, err := hex.DecodeString(config.Hmac_Secret)
+	if err != nil {
+		return []byte(config.Hmac_Secret)
+	}
+	return b
 }

--- a/asyncauth.go
+++ b/asyncauth.go
@@ -1,0 +1,68 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/coreos/go-oidc"
+	"github.com/mesosphere/konvoy-async-auth/pkg/kaal"
+	asyncauth "github.com/mesosphere/konvoy-async-auth/pkg/kaal/server"
+	"github.com/mesosphere/konvoy-async-auth/pkg/kaal/server/storage"
+	"golang.org/x/oauth2"
+)
+
+const (
+	HmacTTL = 300
+)
+
+func SetupAsyncAuth(cluster *Cluster, st storage.TokenStore, basePrefix string) *asyncauth.KonvoyAsyncAuthServer {
+	var scopes []string
+	if len(cluster.Scopes) == 0 {
+		scopes = append(scopes, "openid", "profile", "email", "groups")
+	} else {
+		scopes = cluster.Scopes
+	}
+	ctx := oidc.ClientContext(context.Background(), cluster.Client)
+	s := &asyncauth.KonvoyAsyncAuthServer{
+		Quiet: false,
+		OAuth2Config: &oauth2.Config{
+			ClientID:     cluster.Client_ID,
+			ClientSecret: cluster.Client_Secret,
+			Endpoint:     cluster.Provider.Endpoint(),
+			Scopes:       scopes,
+			RedirectURL:  getAsyncRedirectURI(cluster.Redirect_URI, basePrefix),
+		},
+		Provider:    cluster.Provider,
+		HmacTTL:     HmacTTL,
+		HmacSecret:  []byte(cluster.Config.Hmac_Secret),
+		Storage:     st,
+		OIDCContext: ctx,
+	}
+	register("init", basePrefix, kaal.InitEndpoint, s.AsyncInit)
+	register("callback", basePrefix, kaal.CallbackEndpoint, s.AuthCallback)
+	register("query", basePrefix, kaal.QueryEndpoint, s.Query)
+	register("check token", basePrefix, kaal.CheckEndpoint, s.CheckToken)
+
+	return s
+}
+
+func getAsyncRedirectURI(u, base string) string {
+	parsed, _ := url.Parse(u)
+	parsed.Path = join(base, kaal.CallbackEndpoint)
+	log.Printf("setting async auth redirect url to %s", parsed.String())
+	return parsed.String()
+}
+
+func register(name, base, endpoint string, f func(w http.ResponseWriter, req *http.Request)) {
+	e := join(base, endpoint)
+	http.HandleFunc(e, f)
+	log.Printf("registerd async %s endpoint at %s", name, e)
+}
+
+func join(base, endpoint string) string {
+	return fmt.Sprintf("%s/%s", strings.TrimRight(base, "/"), strings.TrimLeft(endpoint, "/"))
+}

--- a/asyncauth.go
+++ b/asyncauth.go
@@ -21,11 +21,9 @@ const (
 )
 
 func SetupAsyncAuth(cluster *Cluster, st storage.TokenStore, basePrefix string) *asyncauth.KonvoyAsyncAuthServer {
-	var scopes []string
-	if len(cluster.Scopes) == 0 {
-		scopes = append(scopes, "openid", "profile", "email", "groups")
-	} else {
-		scopes = cluster.Scopes
+	scopes := cluster.Scopes
+	if len(scopes) == 0 {
+		scopes = []string{"openid", "profile", "email", "groups"}
 	}
 	ctx := oidc.ClientContext(context.Background(), cluster.Client)
 	s := &asyncauth.KonvoyAsyncAuthServer{

--- a/main.go
+++ b/main.go
@@ -17,8 +17,11 @@ import (
 	"reflect"
 	"regexp"
 	"strings"
+	"time"
 
 	"github.com/coreos/go-oidc"
+	"github.com/mesosphere/konvoy-async-auth/pkg/kaal/server/storage"
+	memstorage "github.com/mesosphere/konvoy-async-auth/pkg/kaal/server/storage/memory"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
@@ -89,6 +92,7 @@ type Config struct {
 	Static_Context_Name  bool
 	Trusted_Root_Ca      []string
 	Trusted_Root_Ca_File string
+	Hmac_Secret          string
 }
 
 func substituteEnvVars(text string) string {
@@ -248,6 +252,18 @@ func start_app(config Config) {
 	log.Printf("Registered static assets handler at: %s", static_uri)
 
 	http.Handle(static_uri, http.StripPrefix(static_uri, fs))
+
+	// Setup async auth service and build routes
+	stg := memstorage.New(false)
+	gc := storage.NewGC(&stg, time.Minute, false, debug)
+	if err := gc.Start(); err != nil {
+		log.Fatalf("error starting GC for async auth: %v", err)
+	}
+
+	// Hack(jr): We only support one provider in konvoy and it is not necessary to identify
+	// cluster scope in this context (all clusters should use the same provider).
+	cluster := &config.Clusters[0]
+	SetupAsyncAuth(cluster, &stg, config.Web_Path_Prefix)
 
 	// Determine whether to use TLS or not
 	switch listenURL.Scheme {

--- a/main.go
+++ b/main.go
@@ -117,6 +117,10 @@ func start_app(config Config) {
 		log.Fatalf("parse listen address: %v", err)
 	}
 
+	if len(config.Hmac_Secret) == 0 {
+		log.Fatalf("Hmac_Secret is not defined in configuration")
+	}
+
 	var s struct {
 		ScopesSupported []string `json:"scopes_supported"`
 	}


### PR DESCRIPTION
Integrates async token library (konvoy async auth) for supporting kubectl credentials plugin

# Testing 
## Current images
* DKA: jaredrodriguez/dex-k8s-authenticator:v1.1.1-cdee-d2iq
* Extrasteps: jaredrodriguez/kubeaddons-addon-initializer:dev

## Deployment changes
https://github.com/mesosphere/kubernetes-base-addons/commit/dc48b05eea61081481110f542aef57f05cd938ec

## Getting the plugin
https://github.com/mesosphere/konvoy-async-auth/releases/tag/v0.1.0-dev

## Configuring kubectl
