### PR TITLE
fix: corrects a bug in multi-cluster support

### DIFF
--- a/asyncauth.go
+++ b/asyncauth.go
@@ -203,10 +203,10 @@ func (config *Config) renderInstructions(w http.ResponseWriter, req *http.Reques
 	if selectCluster == "" {
 		cluster = config.getFirstClusterOrPanic()
 	} else {
-		for _, c := range config.Clusters {
+		for i, c := range config.Clusters {
 			parsed, _ := url.Parse(c.K8s_Master_URI)
 			if parsed.Hostname() == selectCluster {
-				cluster = &c
+				cluster = &config.Clusters[i]
 				break
 			}
 		}

--- a/asyncauth.go
+++ b/asyncauth.go
@@ -219,6 +219,12 @@ func (config *Config) renderInstructions(w http.ResponseWriter, req *http.Reques
 		}
 	}
 
+	// Get the Kommander Cluster CA
+	authCAData := ""
+	if config.Clusters[0].K8s_Ca_Pem != "" {
+		authCAData = base64.StdEncoding.EncodeToString([]byte(config.Clusters[0].K8s_Ca_Pem))
+	}
+
 	parsed, _ := url.Parse(config.Clusters[0].Redirect_URI)
 	appURL := fmt.Sprintf("%s://%s", parsed.Scheme, parsed.Host)
 	asyncAuthURL := fmt.Sprintf("%s%s", appURL, cluster.Config.Web_Path_Prefix)
@@ -237,6 +243,7 @@ func (config *Config) renderInstructions(w http.ResponseWriter, req *http.Reques
 		"profileName":   profileName,
 		"kubeAPI":       cluster.K8s_Master_URI,
 		"caPem":         cluster.K8s_Ca_Pem,
+		"authCAData":    authCAData,
 	}
 
 	w.WriteHeader(http.StatusOK)

--- a/dex-auth.go
+++ b/dex-auth.go
@@ -87,6 +87,13 @@ func (config *Config) getCluster(name string) *Cluster {
 	return nil
 }
 
+func (config *Config) getFirstClusterOrPanic() *Cluster {
+	if len(config.Clusters) < 1 {
+		panic("no clusters have been defined")
+	}
+	return &config.Clusters[0]
+}
+
 func (cluster *Cluster) handleLogin(w http.ResponseWriter, r *http.Request) {
 	var scopes []string
 

--- a/html/static/main.css
+++ b/html/static/main.css
@@ -152,3 +152,9 @@ pre code {
   display: block;
   padding: 20px;
 }
+code {
+  background-color: #1b2029;
+  color: #ffffff;
+  display: block;
+  padding: 20px;
+}


### PR DESCRIPTION
    The instructions where using redirect url to determine cluster hostname,
    resulting in all clusters having the kommander cluster hostname.

    Made some changes to support a better plugin instructions template.