### PR TITLE
feat: support per-cluster scopes in async-auth

### DIFF
--- a/asyncauth.go
+++ b/asyncauth.go
@@ -56,7 +56,7 @@ type FlatProviderMap struct {
 	Clusters []ClusterJSON `json:"clusters"`
 }
 
-func SetupAsyncAuth(cluster *Cluster, st storage.TokenStore, basePrefix string) *asyncauth.KonvoyAsyncAuthServer {
+func SetupAsyncAuth(cluster *Cluster, st storage.TokenStore, basePrefix string, allClusters []Cluster) *asyncauth.KonvoyAsyncAuthServer {
 	scopes := cluster.Scopes
 	if len(scopes) == 0 {
 		scopes = []string{"openid", "profile", "email", "groups"}
@@ -68,7 +68,6 @@ func SetupAsyncAuth(cluster *Cluster, st storage.TokenStore, basePrefix string) 
 			ClientID:     cluster.Client_ID,
 			ClientSecret: cluster.Client_Secret,
 			Endpoint:     cluster.Provider.Endpoint(),
-			Scopes:       scopes,
 			RedirectURL:  getAsyncRedirectURI(cluster.Redirect_URI, basePrefix),
 		},
 		Provider:    cluster.Provider,
@@ -77,18 +76,38 @@ func SetupAsyncAuth(cluster *Cluster, st storage.TokenStore, basePrefix string) 
 		Storage:     st,
 		OIDCContext: ctx,
 	}
-	register("init", basePrefix, kaal.InitEndpoint, s.AsyncInit)
+	register("init", basePrefix, kaal.InitEndpoint, asyncInitWithScopes(s, scopes))
 	register("callback", basePrefix, kaal.CallbackEndpoint, s.AuthCallback)
 	register("query", basePrefix, kaal.QueryEndpoint, s.Query)
+
+	for _, cluster := range allClusters {
+		clusterBasePrefix := getClusterAsyncAuthURL(basePrefix, cluster.Name)
+		register(fmt.Sprintf("init %q", cluster.Name), clusterBasePrefix, kaal.InitEndpoint, asyncInitWithScopes(s, cluster.Scopes))
+		register(fmt.Sprintf("callback %q", cluster.Name), clusterBasePrefix, kaal.CallbackEndpoint, s.AuthCallback)
+		register(fmt.Sprintf("query %q", cluster.Name), clusterBasePrefix, kaal.QueryEndpoint, s.Query)
+	}
+
 	register("check token", basePrefix, kaal.CheckEndpoint, s.CheckToken)
 	register("plugin instructions", basePrefix, "/plugin", cluster.pluginController)
-	register("plugin data", basePrefix, "/plugin/data/json", cluster.getInstructionDataJSON)
+	// register("plugin data", basePrefix, "/plugin/data/json", cluster.getInstructionDataJSON)
 	register("plugin instructions update", basePrefix, "/plugin/data", cluster.Config.renderInstructions)
 	register("plugin provider data", basePrefix, "/plugin/providers", cluster.Config.getClustersByProviders)
 	register("kubeconfig download", basePrefix, "/plugin/kubeconfig", cluster.Config.downloadKubeConfigUnix)
 	register("kubeconfig download windows", basePrefix, "/plugin/kubeconfig_windows", cluster.Config.downloadKubeConfigWindows)
 
 	return s
+}
+
+func getClusterAsyncAuthURL(basePathOrURL, clusterName string) string {
+	return fmt.Sprintf("%s/async-auth/%s", strings.TrimRight(basePathOrURL, "/"), clusterName)
+}
+
+// asyncInitWithScopes prepares scopes for async auth request if scopes are different
+// per cluster.
+func asyncInitWithScopes(s *asyncauth.KonvoyAsyncAuthServer, scopes []string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		s.AsyncInit(w, r, oauth2.SetAuthURLParam("scope", strings.Join(scopes, " ")))
+	}
 }
 
 func getAsyncRedirectURI(u, base string) string {
@@ -231,6 +250,7 @@ func (config *Config) renderInstructions(w http.ResponseWriter, req *http.Reques
 	parsed, _ := url.Parse(config.getFirstClusterOrPanic().Redirect_URI)
 	appURL := fmt.Sprintf("%s://%s", parsed.Scheme, parsed.Host)
 	asyncAuthURL := fmt.Sprintf("%s%s", appURL, cluster.Config.Web_Path_Prefix)
+	clusterAsyncAuthURL := getClusterAsyncAuthURL(asyncAuthURL, cluster.Name)
 
 	parsed, _ = url.Parse(cluster.K8s_Master_URI)
 	clusterName := parsed.Hostname()
@@ -242,7 +262,7 @@ func (config *Config) renderInstructions(w http.ResponseWriter, req *http.Reques
 		"windowsURL":    getDownloadURL(asyncAuthURL, "windows", cluster.Config.PluginVersion, binaryNameWindows),
 		"installPath":   installPath,
 		"runPath":       runPath,
-		"asyncAuthURL":  asyncAuthURL,
+		"asyncAuthURL":  clusterAsyncAuthURL,
 		"clusterName":   clusterName,
 		"profileName":   profileName,
 		"kubeAPI":       cluster.K8s_Master_URI,
@@ -272,7 +292,10 @@ func (config *Config) getClustersByProviders(w http.ResponseWriter, req *http.Re
 	for _, cluster := range config.Clusters {
 		parsed, _ := url.Parse(cluster.K8s_Master_URI)
 		appURL := fmt.Sprintf("%s://%s", parsed.Scheme, parsed.Host)
-		asyncAuthURL := fmt.Sprintf("%s%s", appURL, cluster.Config.Web_Path_Prefix)
+		asyncAuthURL := getClusterAsyncAuthURL(
+			fmt.Sprintf("%s%s", appURL, cluster.Config.Web_Path_Prefix),
+			cluster.Name,
+		)
 
 		m[cluster.Issuer] = append(m[cluster.Issuer], ClusterJSON{
 			Name:            cluster.Name,

--- a/asyncauth.go
+++ b/asyncauth.go
@@ -79,15 +79,16 @@ func SetupAsyncAuth(cluster *Cluster, st storage.TokenStore, basePrefix string, 
 	register("init", basePrefix, kaal.InitEndpoint, asyncInitWithScopes(s, scopes))
 	register("callback", basePrefix, kaal.CallbackEndpoint, s.AuthCallback)
 	register("query", basePrefix, kaal.QueryEndpoint, s.Query)
+	register("check token", basePrefix, kaal.CheckEndpoint, s.CheckToken)
 
 	for _, cluster := range allClusters {
 		clusterBasePrefix := getClusterAsyncAuthURL(basePrefix, cluster.Name)
-		register(fmt.Sprintf("init %q", cluster.Name), clusterBasePrefix, kaal.InitEndpoint, asyncInitWithScopes(s, cluster.Scopes))
-		register(fmt.Sprintf("callback %q", cluster.Name), clusterBasePrefix, kaal.CallbackEndpoint, s.AuthCallback)
-		register(fmt.Sprintf("query %q", cluster.Name), clusterBasePrefix, kaal.QueryEndpoint, s.Query)
+		register(fmt.Sprintf("%q init", cluster.Name), clusterBasePrefix, kaal.InitEndpoint, asyncInitWithScopes(s, cluster.Scopes))
+		register(fmt.Sprintf("%q callback", cluster.Name), clusterBasePrefix, kaal.CallbackEndpoint, s.AuthCallback)
+		register(fmt.Sprintf("%q query", cluster.Name), clusterBasePrefix, kaal.QueryEndpoint, s.Query)
+		register(fmt.Sprintf("%q check token", cluster.Name), clusterBasePrefix, kaal.CheckEndpoint, s.CheckToken)
 	}
 
-	register("check token", basePrefix, kaal.CheckEndpoint, s.CheckToken)
 	register("plugin instructions", basePrefix, "/plugin", cluster.pluginController)
 	// register("plugin data", basePrefix, "/plugin/data/json", cluster.getInstructionDataJSON)
 	register("plugin instructions update", basePrefix, "/plugin/data", cluster.Config.renderInstructions)

--- a/dex-auth.go
+++ b/dex-auth.go
@@ -93,6 +93,14 @@ func (config *Config) getFirstClusterOrPanic() *Cluster {
 	if len(config.Clusters) < 1 {
 		panic("no clusters have been defined")
 	}
+
+	// In DKP the `kubernetes-cluster` name is a special management cluster name.
+	for _, cluster := range config.Clusters {
+		if cluster.Name == "kubernetes-cluster" {
+			return &cluster
+		}
+	}
+
 	return &config.Clusters[0]
 }
 

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.13
 require (
 	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/gorilla/mux v1.8.0
-	github.com/mesosphere/konvoy-async-auth v0.1.3
+	github.com/mesosphere/konvoy-async-auth v0.1.4
 	github.com/spf13/cast v1.5.0
 	github.com/spf13/cobra v1.4.0
 	github.com/spf13/viper v1.11.0

--- a/go.sum
+++ b/go.sum
@@ -325,8 +325,8 @@ github.com/mattn/go-isatty v0.0.11/go.mod h1:PhnuNfih5lzO57/f3n+odYbM4JtupLOxQOA
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
-github.com/mesosphere/konvoy-async-auth v0.1.3 h1:ZLZplS2oXrVpme0oSvafNeh8PBTZLWLkWmCMDgo3cHk=
-github.com/mesosphere/konvoy-async-auth v0.1.3/go.mod h1:4MY6qZsxYlvfDffmGYQIYBtz1IwObw+DQla62eBp9vs=
+github.com/mesosphere/konvoy-async-auth v0.1.4 h1:STVLC68i5uW0pQ/c552xx7MduAcxLaXHDgkQnNnMqCA=
+github.com/mesosphere/konvoy-async-auth v0.1.4/go.mod h1:4MY6qZsxYlvfDffmGYQIYBtz1IwObw+DQla62eBp9vs=
 github.com/miekg/dns v1.1.26/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
 github.com/miekg/dns v1.1.41/go.mod h1:p6aan82bvRIyn+zDIv9xYNUpwa73JcSh9BKwknJysuI=
 github.com/mitchellh/cli v1.1.0/go.mod h1:xcISNoH86gajksDmfB23e/pu+B+GeFRMYmoHXxx3xhI=

--- a/main.go
+++ b/main.go
@@ -298,7 +298,7 @@ func start_app(config Config) {
 	// Hack(jr): We only support one provider in konvoy and it is not necessary to identify
 	// cluster scope in this context (all clusters should use the same provider).
 	cluster := &config.Clusters[0]
-	SetupAsyncAuth(cluster, &stg, config.Web_Path_Prefix)
+	SetupAsyncAuth(cluster, &stg, config.Web_Path_Prefix, config.Clusters)
 
 	// Determine whether to use TLS or not
 	switch listenURL.Scheme {


### PR DESCRIPTION
DKA and async-auth integration was built in a way that it was always requesting token with hardcoded scopes (ignoring scopes config per cluster). This PR changes this behavior and introduces token requests with scopes per cluster config.

JIRA: https://d2iq.atlassian.net/browse/D2IQ-98909