### PR TITLE
feat: multi tenancy for async auth

### DIFF
--- a/asyncauth.go
+++ b/asyncauth.go
@@ -14,6 +14,7 @@ import (
 	"text/template"
 
 	"github.com/coreos/go-oidc"
+	"github.com/mesosphere/dex-k8s-authenticator/pkg/tenancy"
 	"github.com/mesosphere/konvoy-async-auth/pkg/kaal"
 	asyncauth "github.com/mesosphere/konvoy-async-auth/pkg/kaal/server"
 	"github.com/mesosphere/konvoy-async-auth/pkg/kaal/server/storage"
@@ -56,7 +57,13 @@ type FlatProviderMap struct {
 	Clusters []ClusterJSON `json:"clusters"`
 }
 
-func SetupAsyncAuth(cluster *Cluster, st storage.TokenStore, basePrefix string, allClusters []Cluster) *asyncauth.KonvoyAsyncAuthServer {
+func SetupAsyncAuth(
+	cluster *Cluster,
+	st storage.TokenStore,
+	basePrefix string,
+	allClusters []Cluster,
+	tenantsByCluster map[string]*tenancy.Tenant,
+) *asyncauth.KonvoyAsyncAuthServer {
 	scopes := cluster.Scopes
 	if len(scopes) == 0 {
 		scopes = []string{"openid", "profile", "email", "groups"}
@@ -76,14 +83,19 @@ func SetupAsyncAuth(cluster *Cluster, st storage.TokenStore, basePrefix string, 
 		Storage:     st,
 		OIDCContext: ctx,
 	}
-	register("init", basePrefix, kaal.InitEndpoint, asyncInitWithScopes(s, scopes))
+	register("init", basePrefix, kaal.InitEndpoint, asyncInitWithScopes(s, scopes, nil))
 	register("callback", basePrefix, kaal.CallbackEndpoint, s.AuthCallback)
 	register("query", basePrefix, kaal.QueryEndpoint, s.Query)
 	register("check token", basePrefix, kaal.CheckEndpoint, s.CheckToken)
 
 	for _, cluster := range allClusters {
 		clusterBasePrefix := getClusterAsyncAuthURL(basePrefix, cluster.Name)
-		register(fmt.Sprintf("%q init", cluster.Name), clusterBasePrefix, kaal.InitEndpoint, asyncInitWithScopes(s, cluster.Scopes))
+		register(
+			fmt.Sprintf("%q init", cluster.Name),
+			clusterBasePrefix,
+			kaal.InitEndpoint,
+			asyncInitWithScopes(s, cluster.Scopes, tenantsByCluster[cluster.Name]),
+		)
 		register(fmt.Sprintf("%q query", cluster.Name), clusterBasePrefix, kaal.QueryEndpoint, s.Query)
 		register(fmt.Sprintf("%q check token", cluster.Name), clusterBasePrefix, kaal.CheckEndpoint, s.CheckToken)
 	}
@@ -103,9 +115,15 @@ func getClusterAsyncAuthURL(basePathOrURL, clusterName string) string {
 
 // asyncInitWithScopes prepares scopes for async auth request if scopes are different
 // per cluster.
-func asyncInitWithScopes(s *asyncauth.KonvoyAsyncAuthServer, scopes []string) http.HandlerFunc {
+func asyncInitWithScopes(s *asyncauth.KonvoyAsyncAuthServer, scopes []string, tenant *tenancy.Tenant) http.HandlerFunc {
 	return func(w http.ResponseWriter, r *http.Request) {
-		s.AsyncInit(w, r, oauth2.SetAuthURLParam("scope", strings.Join(scopes, " ")))
+		opts := []oauth2.AuthCodeOption{
+			oauth2.SetAuthURLParam("scope", strings.Join(scopes, " ")),
+		}
+		if tenant != nil {
+			opts = append(opts, tenancy.OauthAddTenantId(tenant.ID))
+		}
+		s.AsyncInit(w, r, opts...)
 	}
 }
 

--- a/go.mod
+++ b/go.mod
@@ -15,5 +15,3 @@ require (
 	k8s.io/client-go v0.28.1
 	k8s.io/utils v0.0.0-20230406110748-d93618cff8a2
 )
-
-// replace github.com/mesosphere/konvoy-async-auth => ../konvoy-async-auth

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,7 @@ go 1.13
 require (
 	github.com/coreos/go-oidc v2.2.1+incompatible
 	github.com/gorilla/mux v1.8.0
-	github.com/mesosphere/konvoy-async-auth v0.1.4
+	github.com/mesosphere/konvoy-async-auth v0.1.5
 	github.com/spf13/cast v1.5.0
 	github.com/spf13/cobra v1.4.0
 	github.com/spf13/viper v1.11.0
@@ -15,3 +15,5 @@ require (
 	k8s.io/client-go v0.28.1
 	k8s.io/utils v0.0.0-20230406110748-d93618cff8a2
 )
+
+// replace github.com/mesosphere/konvoy-async-auth => ../konvoy-async-auth

--- a/go.sum
+++ b/go.sum
@@ -325,8 +325,8 @@ github.com/mattn/go-isatty v0.0.11/go.mod h1:PhnuNfih5lzO57/f3n+odYbM4JtupLOxQOA
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/mattn/go-isatty v0.0.14/go.mod h1:7GGIvUiUoEMVVmxf/4nioHXj79iQHKdU27kJ6hsGG94=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
-github.com/mesosphere/konvoy-async-auth v0.1.4 h1:STVLC68i5uW0pQ/c552xx7MduAcxLaXHDgkQnNnMqCA=
-github.com/mesosphere/konvoy-async-auth v0.1.4/go.mod h1:4MY6qZsxYlvfDffmGYQIYBtz1IwObw+DQla62eBp9vs=
+github.com/mesosphere/konvoy-async-auth v0.1.5 h1:VrqbhX3f7of3OxAiLmUNhmQ7Lyk4Uy+3g1uemjpzDPg=
+github.com/mesosphere/konvoy-async-auth v0.1.5/go.mod h1:4MY6qZsxYlvfDffmGYQIYBtz1IwObw+DQla62eBp9vs=
 github.com/miekg/dns v1.1.26/go.mod h1:bPDLeHnStXmXAq1m/Ch/hvfNHr14JKNPMBo3VZKjuso=
 github.com/miekg/dns v1.1.41/go.mod h1:p6aan82bvRIyn+zDIv9xYNUpwa73JcSh9BKwknJysuI=
 github.com/mitchellh/cli v1.1.0/go.mod h1:xcISNoH86gajksDmfB23e/pu+B+GeFRMYmoHXxx3xhI=

--- a/main.go
+++ b/main.go
@@ -80,6 +80,7 @@ type Cluster struct {
 	Client         *http.Client
 	Redirect_URI   string
 	Config         Config
+	TenantId       tenancy.TenantId
 }
 
 // Define our configuration
@@ -178,6 +179,37 @@ func start_app(config Config) {
 
 	commonCallbackPath := path.Join(config.Web_Path_Prefix, "callback")
 
+	tenantsByCluster := map[string]*tenancy.Tenant{}
+	if config.Enable_Multi_Tenancy {
+		tenants, err := tenancy.NewK8sFromEnvironment()
+		if err != nil {
+			log.Fatalf("failed to initialize tenancy k8s client: %s", err)
+		}
+		log.Printf("Starting with multi-tenancy enabled")
+
+		tenantsByCluster, err = tenants.GetTenantsByCluster(context.Background())
+		if err != nil {
+			log.Fatalf("failed to load all clusters tenancy info: %s", err)
+		}
+		log.Printf("loaded tenants by cluster %#v", tenantsByCluster)
+
+		r := mux.NewRouter()
+
+		tenantWorkspaceBasePath := path.Join(config.Web_Path_Prefix, "workspace")
+		wsRouter := r.PathPrefix(tenantWorkspaceBasePath).Subrouter()
+		wsRouter.HandleFunc("/{tenantId}", NewTenancyHandler(
+			tenants, &config, getTenancyTemplate("index-multitenant.html")))
+		http.Handle(tenantWorkspaceBasePath+"/", wsRouter)
+		log.Printf("Registered tenant kubeconfig handler at: %s", tenantWorkspaceBasePath)
+
+		tenantLandingBasePath := path.Join(config.Web_Path_Prefix, "landing")
+		landingRouter := r.PathPrefix(tenantLandingBasePath).Subrouter()
+		landingRouter.HandleFunc("/{tenantId}", NewLandingHandler(
+			tenants, &config, getTenancyTemplate("landing-multitenant.html")))
+		http.Handle(tenantLandingBasePath+"/", landingRouter)
+		log.Printf("Registered tenant landing handler at: %s", tenantLandingBasePath)
+	}
+
 	// Generate handlers for each cluster
 	for i, _ := range config.Clusters {
 		cluster := config.Clusters[i]
@@ -252,6 +284,11 @@ func start_app(config Config) {
 		http.HandleFunc(login_uri, cluster.handleLogin)
 		log.Printf("Registered login handler at: %s", login_uri)
 
+		if tenant, ok := tenantsByCluster[cluster.Name]; ok {
+			log.Printf("Cluster %q tenant id %q\n", cluster.Name, tenant.ID)
+			cluster.TenantId = tenant.ID
+		}
+
 		config.Clusters[i] = cluster
 	}
 
@@ -267,30 +304,6 @@ func start_app(config Config) {
 
 	http.Handle(static_uri, http.StripPrefix(static_uri, fs))
 
-	if config.Enable_Multi_Tenancy {
-		tenants, err := tenancy.NewK8sFromEnvironment()
-		if err != nil {
-			log.Fatalf("failed to initialize tenancy k8s client: %s", err)
-		}
-		log.Printf("Starting with multi-tenancy enabled")
-
-		r := mux.NewRouter()
-
-		tenantWorkspaceBasePath := path.Join(config.Web_Path_Prefix, "workspace")
-		wsRouter := r.PathPrefix(tenantWorkspaceBasePath).Subrouter()
-		wsRouter.HandleFunc("/{tenantId}", NewTenancyHandler(
-			tenants, &config, getTenancyTemplate("index-multitenant.html")))
-		http.Handle(tenantWorkspaceBasePath+"/", wsRouter)
-		log.Printf("Registered tenant kubeconfig handler at: %s", tenantWorkspaceBasePath)
-
-		tenantLandingBasePath := path.Join(config.Web_Path_Prefix, "landing")
-		landingRouter := r.PathPrefix(tenantLandingBasePath).Subrouter()
-		landingRouter.HandleFunc("/{tenantId}", NewLandingHandler(
-			tenants, &config, getTenancyTemplate("landing-multitenant.html")))
-		http.Handle(tenantLandingBasePath+"/", landingRouter)
-		log.Printf("Registered tenant landing handler at: %s", tenantLandingBasePath)
-	}
-
 	// Setup async auth service and build routes
 	stg := memstorage.New(false)
 	gc := storage.NewGC(&stg, time.Minute, false, debug)
@@ -301,7 +314,7 @@ func start_app(config Config) {
 	// Hack(jr): We only support one provider in konvoy and it is not necessary to identify
 	// cluster scope in this context (all clusters should use the same provider).
 	cluster := &config.Clusters[0]
-	SetupAsyncAuth(cluster, &stg, config.Web_Path_Prefix, config.Clusters)
+	SetupAsyncAuth(cluster, &stg, config.Web_Path_Prefix, config.Clusters, tenantsByCluster)
 
 	// Determine whether to use TLS or not
 	switch listenURL.Scheme {

--- a/pkg/tenancy/kubernetes.go
+++ b/pkg/tenancy/kubernetes.go
@@ -30,6 +30,9 @@ var (
 
 const (
 	workspaceNameAnnotation = "kommander.mesosphere.io/display-name"
+
+	// DKA stores management cluster under `kubernetes-cluster` name.
+	managementClusterName = "kubernetes-cluster"
 )
 
 var _ Tenants = &k8sTenants{}
@@ -89,16 +92,7 @@ func (t *k8sTenants) Get(ctx context.Context, tenantId TenantId) (*Tenant, error
 		return nil, err
 	}
 
-	tenant := &Tenant{
-		ID:   tenantId,
-		Name: string(tenantId),
-	}
-
-	if name, ok := workspace.GetAnnotations()[workspaceNameAnnotation]; ok {
-		tenant.Name = name
-	}
-
-	return tenant, nil
+	return tenantFromWorkspace(workspace), nil
 }
 
 // FilterClusterNames gets the list of KC names for given tenant (via Worksspace)
@@ -137,4 +131,56 @@ func (t *k8sTenants) FilterClusterNames(ctx context.Context, tenantId TenantId, 
 	}
 
 	return tenantNames, nil
+}
+
+func (t *k8sTenants) GetTenantsByCluster(ctx context.Context) (map[string]*Tenant, error) {
+	kcList, err := t.client.Resource(kommanderClusterGVR).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	wsList, err := t.client.Resource(workspaceGVR).List(ctx, metav1.ListOptions{})
+	if err != nil {
+		return nil, err
+	}
+
+	tenantsByCluster := map[string]*Tenant{}
+
+	for _, kc := range kcList.Items {
+		// No tenancy is for management cluster which is stored in the dka config
+		// as kubernetes-cluster
+		if kc.GetName() == managementClusterName {
+			continue
+		}
+
+		for i, workspace := range wsList.Items {
+			namespaceName, found, err := unstructured.NestedString(workspace.Object, "status", "namespaceRef", "name")
+			if err != nil {
+				return nil, err
+			}
+
+			if !found {
+				continue
+			}
+
+			if namespaceName == kc.GetNamespace() {
+				tenantsByCluster[kc.GetName()] = tenantFromWorkspace(&wsList.Items[i])
+			}
+		}
+	}
+
+	return tenantsByCluster, nil
+}
+
+func tenantFromWorkspace(u *unstructured.Unstructured) *Tenant {
+	// workspace.name is the tenant id
+	tenant := &Tenant{
+		ID:   TenantId(u.GetName()),
+		Name: u.GetName(),
+	}
+
+	if name, ok := u.GetAnnotations()[workspaceNameAnnotation]; ok {
+		tenant.Name = name
+	}
+	return tenant
 }

--- a/pkg/tenancy/tenants.go
+++ b/pkg/tenancy/tenants.go
@@ -22,4 +22,7 @@ type Tenants interface {
 	// FilterClusterNames returns list of cluster names (from DKA configuration) that belong to
 	// given tenant id.
 	FilterClusterNames(ctx context.Context, tenantId TenantId, names []string) ([]string, error)
+	// GetTenantsByCluster returns list of all known clusters and theirs resolved
+	// tenatn IDs
+	GetTenantsByCluster(ctx context.Context) (map[string]*Tenant, error)
 }

--- a/templates/index.html
+++ b/templates/index.html
@@ -35,7 +35,7 @@
 
             <div class="theme-form-row">
                 <p class="theme-form-description">{{$cluster.Description}}</p>
-                <a href="{{ $.Web_Path_Prefix }}login/{{$cluster.Name}}" target="_self">
+                <a href="{{ $.Web_Path_Prefix }}login/{{$cluster.Name}}?tenant-id={{$cluster.TenantId}}" target="_self">
                   <button class="dex-btn theme-btn-provider">
                     <span class="dex-btn-icon dex-btn-icon--local"></span>
                     <span class="dex-btn-text">{{$cluster.Short_Description}}</span>


### PR DESCRIPTION
Example of URL where client is redirected:

```
To initiate authentication, paste this URL into your browser: https://172.29.255.160/dex/auth?client_id=dex-controller-dex-dka-client-kube-apiserver&redirect_uri=https%3A%2F%2F172.29.255.160%2Ftoken%2Fasync%2Fcallback&response_type=code&scope=openid+profile+email+groups+audience%3Aserver%3Aclient_id%3Adex-controller-dextfa-client-foo-9gq8d&state=66fc2112d8c0a0c96eff6024694372ccbde67b82aa5a570f5f0b888d4b7be67c&tenant-id=foo
```