### PR TITLE
fix: missing management cluster when logging in from management ws

### DIFF
--- a/pkg/tenancy/kubernetes.go
+++ b/pkg/tenancy/kubernetes.go
@@ -33,6 +33,11 @@ const (
 
 	// DKA stores management cluster under `kubernetes-cluster` name.
 	managementClusterName = "kubernetes-cluster"
+
+	// KommanderCluster for management cluster has different name in k8s api
+	// server vs in DKA config file.
+	managementWorkspaceNamespaceName      = "kommander-workspace"
+	managementClusterKommanderClusterName = "host-cluster"
 )
 
 var _ Tenants = &k8sTenants{}
@@ -97,7 +102,7 @@ func (t *k8sTenants) Get(ctx context.Context, tenantId TenantId) (*Tenant, error
 
 // FilterClusterNames gets the list of KC names for given tenant (via Worksspace)
 // and returns list of cluster names for clusters that are in the namespace.
-func (t *k8sTenants) FilterClusterNames(ctx context.Context, tenantId TenantId, names []string) ([]string, error) {
+func (t *k8sTenants) FilterClusterNames(ctx context.Context, tenantId TenantId, dkaConfigNames []string) ([]string, error) {
 	workspace, err := t.client.Resource(workspaceGVR).
 		Get(ctx, string(tenantId), metav1.GetOptions{})
 	if err != nil {
@@ -124,9 +129,15 @@ func (t *k8sTenants) FilterClusterNames(ctx context.Context, tenantId TenantId, 
 	}
 
 	tenantNames := []string{}
-	for _, name := range names {
-		if slices.Contains(kcNames, name) {
-			tenantNames = append(tenantNames, name)
+	for _, dkaConfigClusterName := range dkaConfigNames {
+		if dkaConfigClusterName == managementClusterName && tenantId == managementWorkspaceNamespaceName {
+			if slices.Contains(kcNames, managementClusterKommanderClusterName) {
+				tenantNames = append(tenantNames, dkaConfigClusterName)
+			}
+		} else {
+			if slices.Contains(kcNames, dkaConfigClusterName) {
+				tenantNames = append(tenantNames, dkaConfigClusterName)
+			}
 		}
 	}
 

--- a/pkg/tenancy/kubernetes.go
+++ b/pkg/tenancy/kubernetes.go
@@ -130,6 +130,11 @@ func (t *k8sTenants) FilterClusterNames(ctx context.Context, tenantId TenantId, 
 
 	tenantNames := []string{}
 	for _, dkaConfigClusterName := range dkaConfigNames {
+		// Management cluster name in the DKA config requires special handling, as
+		// because of historical reasons, the management cluster is stored as
+		// `kubernetes-cluster` in the DKA config, while having name `host-cluster`
+		// in K8s API. For this reason we need to check for presence of different
+		// name.
 		if dkaConfigClusterName == managementClusterName && tenantId == managementWorkspaceNamespaceName {
 			if slices.Contains(kcNames, managementClusterKommanderClusterName) {
 				tenantNames = append(tenantNames, dkaConfigClusterName)

--- a/pkg/tenancy/kubernetes.go
+++ b/pkg/tenancy/kubernetes.go
@@ -3,6 +3,7 @@ package tenancy
 import (
 	"context"
 	"fmt"
+	"log"
 
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -103,17 +104,20 @@ func (t *k8sTenants) Get(ctx context.Context, tenantId TenantId) (*Tenant, error
 // FilterClusterNames gets the list of KC names for given tenant (via Worksspace)
 // and returns list of cluster names for clusters that are in the namespace.
 func (t *k8sTenants) FilterClusterNames(ctx context.Context, tenantId TenantId, dkaConfigNames []string) ([]string, error) {
+	log.Printf("FilterClusterNames: %s\n", tenantId)
 	workspace, err := t.client.Resource(workspaceGVR).
 		Get(ctx, string(tenantId), metav1.GetOptions{})
 	if err != nil {
 		return nil, err
 	}
 
+	log.Printf("workspace: %s\n", workspace.GetName())
 	namespaceName, found, err := unstructured.NestedString(workspace.Object, "status", "namespaceRef", "name")
 	if err != nil {
 		return nil, err
 	}
 
+	log.Printf("namespaceName: %s\n", namespaceName)
 	if !found {
 		return nil, fmt.Errorf("namespaceRef.name not populated on workspace: %s", string(tenantId))
 	}
@@ -122,11 +126,15 @@ func (t *k8sTenants) FilterClusterNames(ctx context.Context, tenantId TenantId, 
 	if err != nil {
 		return nil, err
 	}
+	for _, kc := range kcList.Items {
+		log.Printf("kc in the list: %s, %s\n", kc.GetName(), kc.GetNamespace())
+	}
 
 	kcNames := []string{}
 	for _, kc := range kcList.Items {
 		kcNames = append(kcNames, kc.GetName())
 	}
+	log.Printf("kcNames: %v\n", kcNames)
 
 	tenantNames := []string{}
 	for _, dkaConfigClusterName := range dkaConfigNames {
@@ -146,6 +154,7 @@ func (t *k8sTenants) FilterClusterNames(ctx context.Context, tenantId TenantId, 
 		}
 	}
 
+	log.Printf("tenantNames: %v\n", tenantNames)
 	return tenantNames, nil
 }
 
@@ -168,6 +177,8 @@ func (t *k8sTenants) GetTenantsByCluster(ctx context.Context) (map[string]*Tenan
 		if kc.GetName() == managementClusterName {
 			continue
 		}
+
+		log.Printf("cluster: %s\n", kc.GetName())
 
 		for i, workspace := range wsList.Items {
 			namespaceName, found, err := unstructured.NestedString(workspace.Object, "status", "namespaceRef", "name")

--- a/pkg/tenancy/kubernetes_test.go
+++ b/pkg/tenancy/kubernetes_test.go
@@ -218,6 +218,39 @@ func TestK8sTenantsFilterClusterNames(t *testing.T) {
 			clusterNames:  []string{"kc-1", "kc-2"},
 			expectedNames: []string{"kc-1"},
 		},
+		{
+			name: "it keeps management cluster in cluster name",
+			objs: []runtime.Object{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "workspaces.kommander.mesosphere.io/v1alpha1",
+						"kind":       "Workspace",
+						"metadata": map[string]interface{}{
+							"name": "kommander-workspace",
+						},
+						"status": map[string]interface{}{
+							"namespaceRef": map[string]interface{}{
+								"name": "kommander-workspace",
+							},
+						},
+					},
+				},
+				// This is
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "kommander.mesosphere.io/v1beta1",
+						"kind":       "KommanderCluster",
+						"metadata": map[string]interface{}{
+							"name":      "host-cluster",
+							"namespace": "kommander-workspace",
+						},
+					},
+				},
+			},
+			tenantId:      tenancy.TenantId("kommander-workspace"),
+			clusterNames:  []string{"kubernetes-cluster", "kc-2"},
+			expectedNames: []string{"kubernetes-cluster"},
+		},
 	}
 
 	for i := range testCases {


### PR DESCRIPTION
The management cluster is missing when opening the /token page as kommander-workspace due to a naming difference between Kommander and DKA. This PR addresses this by introducing more logging to simplify troubleshooting in the future.

Ref. https://d2iq.atlassian.net/browse/D2IQ-99861