### PR TITLE
fix: Dynamically fetch mgmt cluster name

### DIFF
--- a/pkg/tenancy/kubernetes.go
+++ b/pkg/tenancy/kubernetes.go
@@ -35,10 +35,14 @@ const (
 	// DKA stores management cluster under `kubernetes-cluster` name.
 	managementClusterName = "kubernetes-cluster"
 
-	// KommanderCluster for management cluster has different name in k8s api
-	// server vs in DKA config file.
-	managementWorkspaceNamespaceName      = "kommander-workspace"
-	managementClusterKommanderClusterName = "host-cluster"
+	// managementWorkspaceNamespaceName is the workspace namespace for the management cluster.
+	managementWorkspaceNamespaceName = "kommander-workspace"
+
+	// kommanderNamespace is the namespace where the management KommanderCluster lives.
+	kommanderNamespace = "kommander"
+
+	// kommanderClusterHostLabel is the label used to identify the management KommanderCluster.
+	kommanderClusterHostLabel = "kommander.d2iq.io/host"
 )
 
 var _ Tenants = &k8sTenants{}
@@ -138,13 +142,16 @@ func (t *k8sTenants) FilterClusterNames(ctx context.Context, tenantId TenantId, 
 
 	tenantNames := []string{}
 	for _, dkaConfigClusterName := range dkaConfigNames {
-		// Management cluster name in the DKA config requires special handling, as
-		// because of historical reasons, the management cluster is stored as
-		// `kubernetes-cluster` in the DKA config, while having name `host-cluster`
-		// in K8s API. For this reason we need to check for presence of different
-		// name.
+		// Management cluster name in the DKA config requires special handling: the
+		// management cluster is stored as `kubernetes-cluster` in the DKA config,
+		// while its KommanderCluster name in K8s API is configurable. We look it up
+		// dynamically via the `kommander.d2iq.io/host=true` label.
 		if dkaConfigClusterName == managementClusterName && tenantId == managementWorkspaceNamespaceName {
-			if slices.Contains(kcNames, managementClusterKommanderClusterName) {
+			mgmtName, err := t.getManagementClusterName(ctx)
+			if err != nil {
+				return nil, err
+			}
+			if slices.Contains(kcNames, mgmtName) {
 				tenantNames = append(tenantNames, dkaConfigClusterName)
 			}
 		} else {
@@ -156,6 +163,23 @@ func (t *k8sTenants) FilterClusterNames(ctx context.Context, tenantId TenantId, 
 
 	log.Printf("tenantNames: %v\n", tenantNames)
 	return tenantNames, nil
+}
+
+// getManagementClusterName fetches the name of the management KommanderCluster
+// by listing KommanderClusters in the kommander namespace with the host label.
+func (t *k8sTenants) getManagementClusterName(ctx context.Context) (string, error) {
+	list, err := t.client.Resource(kommanderClusterGVR).
+		Namespace(kommanderNamespace).
+		List(ctx, metav1.ListOptions{
+			LabelSelector: kommanderClusterHostLabel + "=true",
+		})
+	if err != nil {
+		return "", err
+	}
+	if len(list.Items) == 0 {
+		return "", fmt.Errorf("no management KommanderCluster found with label %s=true in namespace %s", kommanderClusterHostLabel, kommanderNamespace)
+	}
+	return list.Items[0].GetName(), nil
 }
 
 func (t *k8sTenants) GetTenantsByCluster(ctx context.Context) (map[string]*Tenant, error) {

--- a/pkg/tenancy/kubernetes.go
+++ b/pkg/tenancy/kubernetes.go
@@ -140,6 +140,16 @@ func (t *k8sTenants) FilterClusterNames(ctx context.Context, tenantId TenantId, 
 	}
 	log.Printf("kcNames: %v\n", kcNames)
 
+	// Pre-fetch the management cluster name when processing the management workspace.
+	var mgmtClusterName string
+	if tenantId == managementWorkspaceNamespaceName {
+		mgmtClusterName, err = t.getManagementClusterName(ctx)
+		if err != nil {
+			return nil, err
+		}
+		log.Printf("management cluster name: %v\n", mgmtClusterName)
+	}
+
 	tenantNames := []string{}
 	for _, dkaConfigClusterName := range dkaConfigNames {
 		// Management cluster name in the DKA config requires special handling: the
@@ -147,11 +157,7 @@ func (t *k8sTenants) FilterClusterNames(ctx context.Context, tenantId TenantId, 
 		// while its KommanderCluster name in K8s API is configurable. We look it up
 		// dynamically via the `kommander.d2iq.io/host=true` label.
 		if dkaConfigClusterName == managementClusterName && tenantId == managementWorkspaceNamespaceName {
-			mgmtName, err := t.getManagementClusterName(ctx)
-			if err != nil {
-				return nil, err
-			}
-			if slices.Contains(kcNames, mgmtName) {
+			if slices.Contains(kcNames, mgmtClusterName) {
 				tenantNames = append(tenantNames, dkaConfigClusterName)
 			}
 		} else {

--- a/pkg/tenancy/kubernetes_test.go
+++ b/pkg/tenancy/kubernetes_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/dynamic/fake"
 
 	"github.com/mesosphere/dex-k8s-authenticator/pkg/tenancy"
@@ -235,13 +236,29 @@ func TestK8sTenantsFilterClusterNames(t *testing.T) {
 						},
 					},
 				},
-				// This is
+				// KommanderCluster for the management cluster; must be in the "kommander"
+				// namespace and carry the host label so getManagementClusterName finds it.
 				&unstructured.Unstructured{
 					Object: map[string]interface{}{
 						"apiVersion": "kommander.mesosphere.io/v1beta1",
 						"kind":       "KommanderCluster",
 						"metadata": map[string]interface{}{
-							"name":      "host-cluster",
+							"name":      "my-custom-host-cluster",
+							"namespace": "kommander",
+							"labels": map[string]interface{}{
+								"kommander.d2iq.io/host": "true",
+							},
+						},
+					},
+				},
+				// The workspace-scoped KommanderCluster (same name, different namespace)
+				// is what appears in kcNames for the workspace list.
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "kommander.mesosphere.io/v1beta1",
+						"kind":       "KommanderCluster",
+						"metadata": map[string]interface{}{
+							"name":      "my-custom-host-cluster",
 							"namespace": "kommander-workspace",
 						},
 					},
@@ -251,6 +268,36 @@ func TestK8sTenantsFilterClusterNames(t *testing.T) {
 			clusterNames:  []string{"kubernetes-cluster", "kc-2"},
 			expectedNames: []string{"kubernetes-cluster"},
 		},
+		{
+			name: "management cluster not found returns error",
+			objs: []runtime.Object{
+				&unstructured.Unstructured{
+					Object: map[string]interface{}{
+						"apiVersion": "workspaces.kommander.mesosphere.io/v1alpha1",
+						"kind":       "Workspace",
+						"metadata": map[string]interface{}{
+							"name": "kommander-workspace",
+						},
+						"status": map[string]interface{}{
+							"namespaceRef": map[string]interface{}{
+								"name": "kommander-workspace",
+							},
+						},
+					},
+				},
+				// No KommanderCluster with the host label exists.
+			},
+			tenantId:      tenancy.TenantId("kommander-workspace"),
+			clusterNames:  []string{"kubernetes-cluster"},
+			errorContains: "no management KommanderCluster found with label kommander.d2iq.io/host=true in namespace kommander",
+		},
+	}
+
+	// Pre-register all GVRs used by FilterClusterNames so the fake client can
+	// handle List calls even when no objects of that type are in the fixture.
+	gvrToListKind := map[schema.GroupVersionResource]string{
+		{Group: "workspaces.kommander.mesosphere.io", Version: "v1alpha1", Resource: "workspaces"}:   "WorkspaceList",
+		{Group: "kommander.mesosphere.io", Version: "v1beta1", Resource: "kommanderclusters"}:        "KommanderClusterList",
 	}
 
 	for i := range testCases {
@@ -258,7 +305,7 @@ func TestK8sTenantsFilterClusterNames(t *testing.T) {
 		t.Run(tc.name, func(tt *testing.T) {
 			tt.Parallel()
 
-			cl := fake.NewSimpleDynamicClient(runtime.NewScheme(), tc.objs...)
+			cl := fake.NewSimpleDynamicClientWithCustomListKinds(runtime.NewScheme(), gvrToListKind, tc.objs...)
 			tenants := tenancy.NewK8sTenants(cl)
 			filtered, err := tenants.FilterClusterNames(context.Background(), tc.tenantId, tc.clusterNames)
 


### PR DESCRIPTION
We no longer hardcode the mgmt cluster name to "host-cluster", so let's dynamically fetch the name.

https://jira.nutanix.com/browse/NCN-113978